### PR TITLE
Generalise to support spectral imager

### DIFF
--- a/scripts/fits-image.py
+++ b/scripts/fits-image.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import argparse
+
+import katsdpimageutils.render as render
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Create image from FITS file written by katsdpimager.'
+    )
+    parser.add_argument('--width', type=int, default=1024,
+                        help='Image width [%(default)s]')
+    parser.add_argument('--height', type=int, default=768,
+                        help='Image height [%(default)s]')
+    parser.add_argument('--dpi', type=float, default=render.DEFAULT_DPI,
+                        help='Dots per inch [%(default)s]')
+    parser.add_argument('--caption', type=str,
+                        help='Caption to add to the image')
+    parser.add_argument('input', help='Input FITS file')
+    parser.add_argument('output', help='Output image file')
+    args = parser.parse_args()
+
+    render.write_image(args.input, args.output, width=args.width, height=args.height,
+                       caption=args.caption)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/fits-image.py
+++ b/scripts/fits-image.py
@@ -7,7 +7,7 @@ import katsdpimageutils.render as render
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Create image from FITS file written by katsdpimager.'
+        description='Create image from FITS file'
     )
     parser.add_argument('--width', type=int, default=1024,
                         help='Image width [%(default)s]')

--- a/scripts/fits-video.py
+++ b/scripts/fits-video.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import argparse
+
+import katsdpimageutils.render as render
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Create video from FITS files written by katsdpimager.'
+    )
+    parser.add_argument('--width', type=int, default=1024,
+                        help='Video width [%(default)s]')
+    parser.add_argument('--height', type=int, default=768,
+                        help='Video height [%(default)s]')
+    parser.add_argument('--fps', type=float, default=5.0,
+                        help='Frames per second [%(default)s]')
+    parser.add_argument('output', help='Output video file')
+    parser.add_argument('input', nargs='+', help='Input FITS files')
+    args = parser.parse_args()
+
+    files = [(None, arg) for arg in args.input]
+    render.write_movie(files, args.output, width=args.width, height=args.height, fps=args.fps)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,9 @@ install_requires =
     astropy
     numpy
 python_requires = >=3.6
+scripts =
+    scripts/fits-image.py
+    scripts/fits-video.py
 
 [options.extras_require]
 test = nose


### PR DESCRIPTION
There are a few changes:
- Include the frequency in the caption, if the image is single-frequency (continuum images should not be affected).
- Make a more robust default for `slices` that should make the scripts slightly more generically useful.
- Add the write_movie function from katsdpimager. It's been somewhat generalised so that it takes the same options added to write_image and will theoretically now support values of `slices` other that `('x', 'y', 0, 0)` (not tested though, and I'm pretty sure both functions will break down if 'y' comes before 'x').
- Move the scripts from katsdpimager.