### PR TITLE
Improve averaging with flagged image plane

### DIFF
--- a/katsdpimageutils/primary_beam_correction.py
+++ b/katsdpimageutils/primary_beam_correction.py
@@ -164,12 +164,10 @@ def inverse_variance(data):
     until either no more pixels are rejected or a maximum of 50 iterations
     is reached.
     """
-    data = data[data != 0.0]
+    data = data[(data != 0.0) & (np.isfinite(data))]
     if len(data) == 0:
         return 0.0
     med, sd = standard_deviation(data)
-    if ~np.isfinite(sd):
-        return 0.0
     for i in range(50):
         old_sd = sd
         cut = np.abs(data - med) < 5.0 * sd

--- a/katsdpimageutils/primary_beam_correction.py
+++ b/katsdpimageutils/primary_beam_correction.py
@@ -168,6 +168,8 @@ def inverse_variance(data):
     if len(data) == 0:
         return 0.0
     med, sd = standard_deviation(data)
+    if ~np.isfinite(sd):
+        return 0.0
     for i in range(50):
         old_sd = sd
         cut = np.abs(data - med) < 5.0 * sd

--- a/katsdpimageutils/test/test_primary_beam_correction.py
+++ b/katsdpimageutils/test/test_primary_beam_correction.py
@@ -42,8 +42,14 @@ class TestInverseVariance:
     def test_all_nans(self):
         data = self.data
         data[:] = np.nan
-        with np.testing.assert_warns(RuntimeWarning):
-            inverse_variance(data)
+        inv_var = inverse_variance(data)
+        assert_equal(inv_var, 0.0)
+
+    def test_mix_nans_zeros(self):
+        data = np.zeros([5])
+        data[0:2] = np.nan
+        inv_var = inverse_variance(data)
+        assert_equal(inv_var, 0.0)
 
     def test_nonans(self):
         data = self.data


### PR DESCRIPTION
In some pipeline images an entire frequency plane may be flagged, in this case the imaged portion of the sky is populated with zeros, while the non-imaged portion is populated with NaNs. The inverse variance calculation for this plane therefore returns a NaN. Using a NaN value as a weight in the weighted average of all the planes results in a NaN output image.

This commit alters the inverse variance calculation to output a zero value for an image composed of all zeros, all NaNs or a combination of both zeros and NaNs which improves the image calculated as the average over all planes.