### PR TITLE
Allow kwargs to pass from `write_image` and `write_movie` to zscale

### DIFF
--- a/katsdpimageutils/render.py
+++ b/katsdpimageutils/render.py
@@ -131,7 +131,7 @@ def write_image(input_file, output_file, width=1024, height=768, dpi=DEFAULT_DPI
         Optional background color to use in the image plot window.
         Blanked pixels in the input FITS image will appear in this color.
     **kwargs : Optional[dict]
-        Extra keyword arguments, passed to `zscale.zscale`.
+        Extra keyword arguments, passed to :func:`zscale.zscale`.
     """
     if not isinstance(input_file, fits.PrimaryHDU):
         with fits.open(input_file) as hdus:

--- a/katsdpimageutils/render.py
+++ b/katsdpimageutils/render.py
@@ -197,7 +197,7 @@ def write_movie(files, output_file, width=1024, height=768, dpi=DEFAULT_DPI, fps
         Optional background color to use in the image plot window.
         Blanked pixels in the input FITS image will appear in this color.
     **kwargs : Optional[dict]
-        Extra keyword arguments, passed to `zscale.zscale`.
+        Extra keyword arguments, passed to :func:`zscale.zscale`.
     """
     # Load the last image to get its WCS
     with fits.open(files[-1][1]) as hdus:


### PR DESCRIPTION
This will allow tuning of contrast scaling parameters depending on image product being converted to PNG format.