### PR TITLE
Update .pre-commit-config.yaml to use same flake8 as Jenkins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.7
+  rev: 3.9.2
   hooks:
     - id: flake8
 - repo: https://github.com/pre-commit/mirrors-mypy

--- a/katsdpimageutils/render.py
+++ b/katsdpimageutils/render.py
@@ -18,14 +18,14 @@ from astropy.wcs import WCS
 from astropy import units
 import astropy.io.fits as fits
 from matplotlib import use
-use('Agg')  # noqa: E402
-import matplotlib.axes
-import matplotlib.figure
-import matplotlib.animation as animation
-from mpl_toolkits.axes_grid1 import make_axes_locatable
-import numpy as np
+use('Agg')                                                  # noqa: E402
+import matplotlib.axes                                      # noqa: E402
+import matplotlib.figure                                    # noqa: E402
+import matplotlib.animation as animation                    # noqa: E402
+from mpl_toolkits.axes_grid1 import make_axes_locatable     # noqa: E402
+import numpy as np                                          # noqa: E402
 
-from . import zscale
+from . import zscale                                        # noqa: E402
 
 
 DEFAULT_DPI = 96


### PR DESCRIPTION
I had to sprinkle some extra `noqa: E402` around since flake8 has
changed where it prints the warnings.