### PR TITLE
Primary beam correction optimisations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
     - id: flake8

--- a/scripts/fits-primarybeamimage.py
+++ b/scripts/fits-primarybeamimage.py
@@ -38,11 +38,10 @@ def main():
                  'katbeam module (https://github.com/ska-sa/katbeam.git).')
     raw_image = pbc.read_fits(path)
     beam_model = pbc.get_beam_model(raw_image.header)
-    bp = pbc.beam_pattern(raw_image.header, beam_model)
     # pbc - primary beam corrected
     logging.info('----------------------------------------')
     logging.info('Doing the primary beam correction in each frequency plane and averaging')
-    pbc_image = pbc.primary_beam_correction(bp, raw_image, px_cut=0.1)
+    pbc_image = pbc.primary_beam_correction(beam_model, raw_image, px_cut=0.1)
     logging.info('----------------------------------------')
     logging.info('Saving the primary beam corrected image')
     fpath, fext = os.path.splitext(path)

--- a/scripts/fits-primarybeamimage.py
+++ b/scripts/fits-primarybeamimage.py
@@ -36,11 +36,12 @@ def main():
     logging.info('----------------------------------------')
     logging.info('Getting the beam pattern for each frequency plane based on the '
                  'katbeam module (https://github.com/ska-sa/katbeam.git).')
-    bp = pbc.beam_pattern(path)
+    raw_image = pbc.read_fits(path)
+    beam_model = pbc.get_beam_model(raw_image.header)
+    bp = pbc.beam_pattern(raw_image.header, beam_model)
     # pbc - primary beam corrected
     logging.info('----------------------------------------')
     logging.info('Doing the primary beam correction in each frequency plane and averaging')
-    raw_image = pbc.read_fits(path)
     pbc_image = pbc.primary_beam_correction(bp, raw_image, px_cut=0.1)
     logging.info('----------------------------------------')
     logging.info('Saving the primary beam corrected image')


### PR DESCRIPTION
This does a few things:

It fixes a bug in `inverse_variance` that was causing it to do all of its 50 iterations every time, rather than terminating after the measured variance is unchanged from the previous iteration. Normally the stopping criterion is reached after 5 or so iterations. This speeds up the `inverse_variance` function usually by a factor of 10, and since this was the greatest time hog of the whole primary beam correction, it speeds up the whole module by roughly the same factor.

It improves the call to `wcs.pixel_to_skycoord` to stop it from computing the world coordinates of the Stokes and Frequency axes in the image. Saving 3 times the memory usage in the call.

Finally, it computes a weighted average by accumulating the weighted and beam corrected coarse frequency planes one at a time, and dividing by the sum of weights at the end. This greatly improves memory usage for images with many coarse frequency planes attached.