### PR TITLE
Use float instead of np.float

### DIFF
--- a/katsdpimageutils/primary_beam_correction.py
+++ b/katsdpimageutils/primary_beam_correction.py
@@ -275,7 +275,7 @@ def primary_beam_correction(beam_model, raw_image, px_cut=0.1):
     nterm = raw_image.header['NTERM']
     nspec = raw_image.header['NSPEC']
     image_data = raw_image.data
-    weights = np.empty(nspec, dtype=np.float)
+    weights = np.empty(nspec, dtype=float)
     # Frequencies are in increasing order (from MGImage)
     freqs = central_freq(raw_image.header)
     # Get an array of pixel offsets in degrees

--- a/katsdpimageutils/test/test_primary_beam_correction.py
+++ b/katsdpimageutils/test/test_primary_beam_correction.py
@@ -99,8 +99,8 @@ class TestGetValueFromHistory:
 class TestWeightedAverage:
     def setup(self):
         self.data = np.array([10., 25., 30., 60., 100.])
-        self.beam = np.ones(5, dtype=np.float)
-        self.out = np.zeros(5, dtype=np.float)
+        self.beam = np.ones(5, dtype=float)
+        self.out = np.zeros(5, dtype=float)
         self.MAD_TO_SD = 1.4826
 
     def test_nonans(self):


### PR DESCRIPTION
`np.float` is deprecated as of NumPy 1.20 and will not work at all after 1.24. Use the builtin `float` instead.